### PR TITLE
Fix hover check

### DIFF
--- a/goal_src/jak2/engine/target/board/board-states.gc
+++ b/goal_src/jak2/engine/target/board/board-states.gc
@@ -120,6 +120,8 @@
   (none)
   )
 
+(define-extern *target-board-hold-tricks* int)
+
 ;; WARN: Return type mismatch object vs none.
 (defbehavior target-board-spin-check target ()
   (when (and (or (cpad-pressed? (-> self control cpad number) r1)
@@ -245,6 +247,7 @@
                         )
                    )
           (set! (-> self board unknown-float01) f28-1)
+          (+! *target-board-hold-tricks* 1)
           (go
             target-board-hold
             (-> *TARGET_BOARD-bank* tricky-jump-height-min)
@@ -1645,11 +1648,9 @@
   :post target-board-post
   )
 
-(define-extern *target-board-hold-tricks* int)
 (defstate target-board-hold (target)
   :event (-> target-board-jump event)
   :enter (behavior ((arg0 float) (arg1 float) (arg2 symbol))
-    (+! *target-board-hold-tricks* 1)
     (set! (-> self control unknown-word04) (the-as uint arg2))
     (forward-up-nopitch->quaternion
       (-> self control dir-targ)
@@ -1677,7 +1678,9 @@
     (set! (-> self control dynam gravity-length) 147456.0)
     )
   :exit (behavior ()
-    (set! *target-board-hold-tricks* 0)
+    (when (and (-> self next-state) (!= 'target-board-hold (-> self next-state name)))
+      (set! *target-board-hold-tricks* 0)
+      )
     (set! (-> self board unknown-float01) 0.0)
     (set-time! (-> self board unknown-time-frame05))
     (let ((v1-3 (the-as sound-rpc-set-param (get-sound-buffer-entry))))
@@ -1734,7 +1737,6 @@
                   (ja :num! (loop!))
                   )
                  (else
-                   (+! *target-board-hold-tricks* 1)
                    (add-to-trick-list (-> self board) (board-tricks board-method) 500.0)
                    (set! (-> self board unknown-sound-id01) (sound-play "board-method"))
                    (ja-channel-push! 1 (seconds 0.08))
@@ -1754,7 +1756,6 @@
              (ja :num! (loop!))
              )
             ((< 40960.0 (target-height-above-ground))
-             (+! *target-board-hold-tricks* 1)
              (add-to-trick-list (-> self board) (board-tricks board-nosegrab) 500.0)
              (set! (-> self board unknown-sound-id01) (sound-play "board-nosegrab"))
              (ja-channel-push! 1 (seconds 0.08))

--- a/goal_src/jak2/engine/target/board/target-board.gc
+++ b/goal_src/jak2/engine/target/board/target-board.gc
@@ -2936,6 +2936,7 @@
         (end-combo! *board-trick-tracker*))
       )
     )
+  (set! *target-board-hold-tricks* 0)
   (set! (-> this trick-count) 0)
   0
   0


### PR DESCRIPTION
counter was previously getting reset to 0 too early in the `target-board-hold` exit (i.e. when going from `target-board-hold` right back to `target-board-hold`, we shouldn't reset it yet).

after fixing that I realized the places I was incrementing it were incorrect - it's cleanest just to increment any time we go to  `target-board-hold` (L1 + up/down trick)