### PR TITLE
Give release-pipeline write permissions

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+
 jobs:
   # Windows
   build_windows_clang:


### PR DESCRIPTION
Allows the workflow to upload artifacts with the default github token.

fixes #73 