### PR TITLE
Default custom-hacky? to #f for non-custom nav-meshes.

### DIFF
--- a/goal_src/jak1/engine/nav/navigate.gc
+++ b/goal_src/jak1/engine/nav/navigate.gc
@@ -934,7 +934,9 @@
         (format #t "WARNING:  nav-mesh only contains gap triangles (~D triangles total). " s5-0)
         (set! gp-0 #t))
       (when gp-0
-        (if pp (format #t "current process is ~A~%" (-> pp name)) (format #t "(no current process).~%"))))
+        (if pp (format #t "current process is ~A~%" (-> pp name)) (format #t "(no current process).~%")))
+      (when (zero? (-> this custom-hacky?))
+        (set! (-> this custom-hacky?) #f)))
     0
     (none)))
 


### PR DESCRIPTION
Fixes the orbit-plats in LPC, as they seem to rely on this function that `custom-hacky?` is intended to skip. The problem is if `custom-hacky?` is not defined, it defaults to 0, which is truthy, so we skip the function for those platforms. 

To fix this, in `initialize-mesh!` we determine if the flag has yet to be set (by being 0) and set it to #f.