### PR TITLE
jak1: fix custom debug continue point

### DIFF
--- a/goal_src/jak1/engine/game/game-info.gc
+++ b/goal_src/jak1/engine/game/game-info.gc
@@ -22,9 +22,6 @@
 
 (define-extern runs-on-jak-death (function symbol none))
 
-;;Forward declaration Variable for mod base settings
-(define-extern startingDebugContinuePoint (string))
-
 ;; DECOMP BEGINS
 
 ;;;;;;;;;;;;;;;;;;
@@ -185,7 +182,6 @@
                     (cond
                       (continue-point-override (empty) continue-point-override)
                       ((!= *kernel-boot-message* 'play) "demo-start")
-                      ((and *debug-segment* (not (string= startingDebugContinuePoint "village1-hut"))) startingDebugContinuePoint) ;; mod-base-change
                       (*debug-segment* "village1-hut")
                       (else "title-start")))
      (set! (-> this auto-save-count) 0)

--- a/goal_src/jak1/engine/level/level.gc
+++ b/goal_src/jak1/engine/level/level.gc
@@ -1001,6 +1001,8 @@
   (set! *print-login* #f)
   0)
 
+(define-extern *debug-continue-point* string)
+
 (defun play ((use-vis symbol) (init-game symbol))
   "The entry point to the actual game! This allocates the level heaps, loads some data, sets some default parameters and sets the startup level."
   ;; temp
@@ -1008,9 +1010,13 @@
   (format 0 "(play :use-vis ~A :init-game ~A) has been called!~%" use-vis init-game)
   (format 0 "*kernel-boot-message*: ~A~%" *kernel-boot-message*)
   ;;(kernel-shutdown)
-  (let ((startup-level (case *kernel-boot-message*
-                         (('play) (if *debug-segment* 'village1 'title))
-                         (else 'demo))))
+  ;; og:mod-base use custom continue point
+  (let* ((debug-cont (if (and *debug-segment* (nonzero? *debug-continue-point*)) (get-continue-by-name *game-info* *debug-continue-point*)))
+         (startup-level (if debug-cont
+                          (-> debug-cont level)
+                          (case *kernel-boot-message*
+                            (('play) (if *debug-segment* 'village1 'title))
+                            (else 'demo)))))
     (stop 'play)
     (set! (-> *level* vis?) use-vis)
     (set! (-> *level* want-level) #f)
@@ -1042,7 +1048,11 @@
   (on #t)
   (load-dbg "Display started: ~A~%" *dproc*)
   (when init-game
-    (initialize! *game-info* 'game (the-as game-save #f) (the-as string #f)))
+    ;; og:mod-base use custom continue point
+    (initialize! *game-info*
+                 'game
+                 (the-as game-save #f)
+                 (if (and *debug-segment* (nonzero? *debug-continue-point*)) *debug-continue-point* (the string #f))))
   0)
 
 (defun update-sound-banks ()

--- a/goal_src/jak1/engine/mods/mod-settings.gc
+++ b/goal_src/jak1/engine/mods/mod-settings.gc
@@ -35,7 +35,7 @@ if the result of rand-vu-int-range is 1, then DANCE! if it is not 1, then Don't 
 ;; Define Settings to use in mods
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define startingDebugContinuePoint "village1-hut")
+(define *debug-continue-point* "village1-hut")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Define Custom Settings Variables to use in mods


### PR DESCRIPTION
Previously, the way the custom debug continue point added by the mod base was implemented would always cause `village1` to be loaded first and only right after that would it actually try to put you in the desired level, leading to longer startup times.