### PR TITLE
Reduce auto-mount distance on Lava Tube racers.

### DIFF
--- a/goal_src/jak1/levels/racer_common/racer.gc
+++ b/goal_src/jak1/levels/racer_common/racer.gc
@@ -162,7 +162,8 @@
     (set! (-> self root root-prim prim-core action) (collide-action solid attackable-unused))
     (set! (-> self root root-prim prim-core offense) (collide-offense indestructible))
     0.0
-    (let ((f30-0 (if (= (-> self condition) 4) 61440.0 20480.0)))
+    ;; <modbase:preserve-this> Reduce auto-mount distance from 15 meters to 6 meters to avoid crash in Lava Tube.
+    (let ((f30-0 (if (= (-> self condition) 4) 24576.0 20480.0)))
       (loop
         (if (and *target* (logtest? (-> *target* control root-prim prim-core action) (collide-action racer)))
           (go-virtual wait-for-return))


### PR DESCRIPTION
Normally, the distance needed for Jak to interact with any racer pad is 5 meters. However, because the Lava Tube checkpoint pads have Condition 4, their interaction radius is massively increased to 15 meters. In addition, Condition 4 forces Jak to mount the zoomer when her enters that radius.

This creates an unfortunate paradox. Jak is forced to mount the zoomer as soon as he is 15 meters away from the pad, but (my suspicion is) Jak's mounting animation doesn't work at that distance. Something about the racer entering the `pickup` state like this causes the game to crash. 

The easiest way to make this happen is by using the debug menu to forcibly dismount Jak after spawning him at those continue points, but you can fly Jak to those pads and the game will crash without you getting on/off the zoomer, and without you touching the ground, as soon as you get within 15 meters.

Reducing this radius to 6 meters puts Jak back within a safe radius for the mounting animation to work. 6 meters is the perfect distance: in Lava Tube's midway continue points, Jak never spawns more than 6 meters away from the pad. And because this new radius can be set _exclusively_ for Condition 4 racer pads, this will cause no regression to other racer pads throughout the world.

As far as modded levels go, I don't think one exists yet with a Condition 4 racer actor, but for any modder that does want to use one, as long they create a continue point and spawn Jak within 6 meters (just about where the metal of the pad meets the terrain) then the auto-mount should work, and forcibly removing Jak from the zoomer near the pad would not cause the game to crash.