### PR TITLE
fix MODVERSIONPLACEHOLDER stuff

### DIFF
--- a/.github/scripts/releases/replace-mod-version-timestamp.py
+++ b/.github/scripts/releases/replace-mod-version-timestamp.py
@@ -18,7 +18,7 @@ def patch_mod_timestamp(goal_src_path):
             # Check if the placeholder string is present in the file
             if "%MODVERSIONPLACEHOLDER%" in file_data:
                 # Replace the placeholder string with the version and date string
-                version_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                version_str = os.getenv("versionName") + " " + datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
                 file_data = file_data.replace("%MODVERSIONPLACEHOLDER%", version_str)
                 # Write the updated content back to the mod-settings
                 file = open(settings_file_path, "w")

--- a/.github/workflows/mod-release-pipeline.yml
+++ b/.github/workflows/mod-release-pipeline.yml
@@ -149,9 +149,12 @@ jobs:
         run: ls -Rl ./ci-artifacts/
 
       - name: Prepare Windows Build Assets
+        env:
+          versionName: ${{ needs.create_release.outputs.bundleTagName }}
         run: |
           mkdir -p ./ci-artifacts/windows
           mkdir -p ${{ inputs.outputDir }}/dist
+          versionName=${{ needs.create_release.outputs.bundleTagName }}
           chmod +x ./.github/scripts/releases/extract_mod_build_windows.sh
           ./.github/scripts/releases/extract_mod_build_windows.sh ./ci-artifacts/windows ./ci-artifacts/opengoal-windows-static ./
           TAG_VAL=${{ needs.create_release.outputs.bundleTagName }}
@@ -203,9 +206,12 @@ jobs:
         run: ls -Rl ./ci-artifacts/
 
       - name: Prepare Linux Build Assets
+        env:
+          versionName: ${{ needs.create_release.outputs.bundleTagName }}
         run: |
           mkdir -p ./ci-artifacts/linux
           mkdir -p ${{ inputs.outputDir }}/dist
+          versionName=${{ needs.create_release.outputs.bundleTagName }}
           chmod +x ./.github/scripts/releases/extract_mod_build_unix.sh
           ./.github/scripts/releases/extract_mod_build_unix.sh ./ci-artifacts/linux ./ci-artifacts/opengoal-linux-static ./
           pushd ci-artifacts/linux
@@ -259,9 +265,12 @@ jobs:
         run: ls -Rl ./ci-artifacts/
 
       - name: Prepare MacOS Build Assets
+        env:
+          versionName: ${{ needs.create_release.outputs.bundleTagName }}
         run: |
           mkdir -p ./ci-artifacts/macos-intel
           mkdir -p ${{ inputs.outputDir }}/dist
+          versionName=${{ needs.create_release.outputs.bundleTagName }}
           chmod +x ./.github/scripts/releases/extract_mod_build_unix.sh
           ./.github/scripts/releases/extract_mod_build_unix.sh ./ci-artifacts/macos-intel ./ci-artifacts/opengoal-macos-static ./
           pushd ci-artifacts/macos-intel


### PR DESCRIPTION
apparently this broke during the workflow rewrites and we were only replacing with the timestamp. this adds back the v0.0.1 version part