### PR TITLE
Jak 2: Use callbacks in warp gate menu entries

### DIFF
--- a/goal_src/jak2/engine/mods/air-train-menu/air-train-menu-h.gc
+++ b/goal_src/jak2/engine/mods/air-train-menu/air-train-menu-h.gc
@@ -14,8 +14,8 @@
   ((level-name    symbol) ;; level name
    (continue-name string) ;; name of the checkpoint Jak will be teleported to
    (text-id       text-id) ;; text ID that defines the name displayed for this destination in the menu 
-   (allow-when    string) ;; optional: the task node that must be completed for this entry to become available
-   (forbid-when   string) ;; optional: if the specified task node is completed, this entry will be hidden regardless of `allow-when`
+   (allow-when    (function symbol)) ;; optional: function that must return true for this entry to become available
+   (forbid-when   (function symbol)) ;; optional: function that hides this entry if it returns true, regardless of `allow-when`
    (on-activate   pair) ;; optional: actions executed when the destination is selected (e.g., play scenes, load levels, close tasks)
    )  
   )
@@ -46,7 +46,7 @@
                 :level-name 'caspad
                 :continue-name "caspad-warp"
                 :text-id (text-id caspad-name) ;"Landing Pad"
-                :allow-when "dig-knock-down-introduction"  ;; first dig mission required
+                :allow-when (lambda () (task-closed? "dig-knock-down-introduction"))  ;; first dig mission required
                 :forbid-when #f
                 :on-activate '(scene-play '("city-air-train-in-caspad" "caspad-air-train-out"))
                 )
@@ -54,7 +54,7 @@
                 :level-name 'nest
                 :continue-name "nest-warp"
                 :text-id (text-id nest-name) ;"Metal Head Nest"
-                :allow-when "nest-get-to-gun-introduction"  ;; first nest mission required
+                :allow-when (lambda () (task-closed? "nest-get-to-gun-introduction"))  ;; first nest mission required
                 :forbid-when #f
                 :on-activate '(scene-play '("city-air-train-in-nest" "nest-air-train-out"))
                 )
@@ -67,7 +67,7 @@
                 :level-name 'ctyport
                 :continue-name "ctyport-warp"
                 :text-id (text-id ctyport-name) ;"Haven City Port"
-                :allow-when "dig-knock-down-introduction"  ;; first dig mission required
+                :allow-when (lambda () (task-closed? "dig-knock-down-introduction"))  ;; first dig mission required
                 :forbid-when #f
                 :on-activate '(scene-play '("caspad-air-train-in" "city-air-train-out"))
                 )
@@ -75,7 +75,7 @@
                 :level-name 'nest
                 :continue-name "nest-warp"
                 :text-id (text-id nest-name) ;"Metal Head Nest"
-                :allow-when "nest-get-to-gun-introduction"  ;; first nest mission required
+                :allow-when (lambda () (task-closed? "nest-get-to-gun-introduction"))  ;; first nest mission required
                 :forbid-when #f
                 :on-activate '(scene-play '("caspad-air-train-in" "nest-air-train-out"))
                 )
@@ -88,7 +88,7 @@
                 :level-name 'ctyport
                 :continue-name "ctyport-warp"
                 :text-id (text-id ctyport-name) ;"Haven City Port"
-                :allow-when "nest-get-to-gun-introduction"  ;; first nest mission required
+                :allow-when (lambda () (task-closed? "nest-get-to-gun-introduction"))  ;; first nest mission required
                 :forbid-when #f
                 :on-activate '(scene-play '("nest-air-train-in" "city-air-train-out"))
                 )
@@ -96,7 +96,7 @@
                 :level-name 'caspad
                 :continue-name "caspad-warp"
                 :text-id (text-id caspad-name) ;"Landing Pad"
-                :allow-when "nest-get-to-gun-introduction"  ;; first nest mission required
+                :allow-when (lambda () (task-closed? "nest-get-to-gun-introduction"))  ;; first nest mission required
                 :forbid-when #f
                 :on-activate '(scene-play '("nest-air-train-in" "caspad-air-train-out"))
                 )

--- a/goal_src/jak2/engine/mods/air-train-menu/air-train-menu.gc
+++ b/goal_src/jak2/engine/mods/air-train-menu/air-train-menu.gc
@@ -11,12 +11,12 @@
           (available-count 0) ;; stores the amount of options that are available for selection 
           )
     (dotimes (i list-length)
-      (let* ((allow-task (-> menu i allow-when))
-              (forbid-task (-> menu i forbid-when))
-              )
-        ;; include the option if the `allow-when` task is closed,
-        ;; and the `forbid-when` task is either not set or not closed yet.
-        (when (and (or (not allow-task) (task-closed? allow-task)) (or (not forbid-task) (not (task-closed? forbid-task))))
+      (let* ((allowed? (-> menu i allow-when))
+             (forbidden? (-> menu i forbid-when)))
+        ;; include the option if `allowed?` is set and returns true,
+        ;; and `forbidden?` is either not set (not forbidden?) or does not return true (not (forbidden?)).
+        (when (and (or (not allowed?) (allowed?)) 
+                   (or (not forbidden?) (not (forbidden?))))
           (set! (-> available-idxs available-count) i) ;; store the available option indexes in `available-idxs` array  
           (+! available-count 1)
           )
@@ -202,10 +202,12 @@
           (list-length (-> menu length))
           )
     (dotimes (i list-length)
-      (let* ((allow-task (-> menu i allow-when))
-              (forbid-task (-> menu i forbid-when))
-              )
-        (when (and (or (not allow-task) (task-closed? allow-task)) (or (not forbid-task) (not (task-closed? forbid-task))))
+      (let* ((allowed? (-> menu i allow-when))
+             (forbidden? (-> menu i forbid-when)))
+        ;; include the option if `allowed?` is set and returns true,
+        ;; and `forbidden?` is either not set (not forbidden?) or does not return true (not (forbidden?)).
+        (when (and (or (not allowed?) (allowed?)) 
+                   (or (not forbidden?) (not (forbidden?))))
           (return #t)
           )
         )

--- a/goal_src/jak2/engine/mods/warp-gate-menu/warp-gate-menu-h.gc
+++ b/goal_src/jak2/engine/mods/warp-gate-menu/warp-gate-menu-h.gc
@@ -14,8 +14,8 @@
   ((level-name    symbol) ;; level name
    (continue-name string) ;; name of the checkpoint Jak will be teleported to
    (text-id       text-id) ;; text ID that defines the name displayed for this destination in the menu 
-   (allow-when    string) ;; optional: the task node that must be completed for this entry to become available
-   (forbid-when   string) ;; optional: if the specified task node is completed, this entry will be hidden regardless of `allow-when`
+   (allow-when    (function symbol)) ;; optional: function that must return true for this entry to become available
+   (forbid-when   (function symbol)) ;; optional: function that hides this entry if it returns true, regardless of `allow-when`
    (on-activate   pair) ;; optional: actions executed when the destination is selected (e.g., play scenes, load levels, close tasks)
    (wait-for      pair)
    (on-close      pair)
@@ -53,22 +53,22 @@
                 :continue-name "strip-warp"
                 :text-id (text-id strip-name) ;"Strip Mine"
                 :allow-when #f
-                :forbid-when "city-power-introduction" ;; unavailable from the city guard turret mission
+                :forbid-when (lambda () (task-closed? "city-power-introduction")) ;; unavailable from the city guard turret mission
                 :on-activate #f
                 )
               (static-warp-gate-menu-entry
                 :level-name 'drillmid
                 :continue-name "drill1-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "drill-eggs-introduction"  ;; first drill platform mission required
-                :forbid-when "city-power-introduction" ;; unavailable from the city guard turret mission
+                :allow-when (lambda () (task-closed? "drill-eggs-introduction"))  ;; first drill platform mission required
+                :forbid-when (lambda () (task-closed? "city-power-introduction")) ;; unavailable from the city guard turret mission
                 :on-activate #f
                 )
               (static-warp-gate-menu-entry 
                 :level-name 'strip
                 :continue-name "strip-warp"
                 :text-id (text-id strip-name) ;"Strip Mine"
-                :allow-when "strip-grenade-introduction" ;; second strip mine mission required
+                :allow-when (lambda () (task-closed? "strip-grenade-introduction")) ;; second strip mine mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -76,7 +76,7 @@
                 :level-name 'drillmid
                 :continue-name "drill3-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "drill-mech-introduction"  ;; third drill platform mission required
+                :allow-when (lambda () (task-closed? "drill-mech-introduction"))  ;; third drill platform mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -84,7 +84,7 @@
                 :level-name 'drillmid
                 :continue-name "drill-warp-gunship"
                 :text-id (text-id drill-name-2) ;"Drill Platform (Warp 2)"
-                :allow-when "drill-ship-introduction"  ;; second drill platform mission required
+                :allow-when (lambda () (task-closed? "drill-ship-introduction"))  ;; second drill platform mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -105,15 +105,15 @@
                 :level-name 'drillmid
                 :continue-name "drill1-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "drill-eggs-introduction" ;; first drill platform mission required
-                :forbid-when "city-power-introduction" ;; unavailable from the city guard turret mission
+                :allow-when (lambda () (task-closed? "drill-eggs-introduction")) ;; first drill platform mission required
+                :forbid-when (lambda () (task-closed? "city-power-introduction")) ;; unavailable from the city guard turret mission
                 :on-activate #f
                 )
               (static-warp-gate-menu-entry
                 :level-name 'drillmid
                 :continue-name "drill3-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "drill-mech-introduction"  ;; third drill platform mission required
+                :allow-when (lambda () (task-closed? "drill-mech-introduction"))  ;; third drill platform mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -121,7 +121,7 @@
                 :level-name 'drillmid
                 :continue-name "drill-warp-gunship"
                 :text-id (text-id drill-name-2) ;"Drill Platform (Warp 2)"
-                :allow-when "drill-ship-introduction" ;; second drill platform mission required
+                :allow-when (lambda () (task-closed? "drill-ship-introduction")) ;; second drill platform mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -142,15 +142,15 @@
                 :level-name 'drillmid
                 :continue-name "drill1-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "drill-eggs-introduction" ;; first drill platform mission required
-                :forbid-when "city-power-introduction" ;; unavailable from the city guard turret mission
+                :allow-when (lambda () (task-closed? "drill-eggs-introduction")) ;; first drill platform mission required
+                :forbid-when (lambda () (task-closed? "city-power-introduction")) ;; unavailable from the city guard turret mission
                 :on-activate #f
                 )
               (static-warp-gate-menu-entry
                 :level-name 'drillmid
                 :continue-name "drill3-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "drill-mech-introduction"  ;; third drill platform mission required
+                :allow-when (lambda () (task-closed? "drill-mech-introduction"))  ;; third drill platform mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -158,7 +158,7 @@
                 :level-name 'drillmid
                 :continue-name "drill-warp-gunship"
                 :text-id (text-id drill-name-2) ;"Drill Platform (Warp 2)"
-                :allow-when "drill-ship-introduction" ;; second drill platform mission required
+                :allow-when (lambda () (task-closed? "drill-ship-introduction")) ;; second drill platform mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -192,7 +192,7 @@
                 :level-name 'vinroom
                 :continue-name "vinroom-warp"
                 :text-id (text-id vinroom-name) ;"Power Station"
-                :allow-when "drill-eggs-resolution"
+                :allow-when (lambda () (task-closed? "drill-eggs-resolution"))
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -200,7 +200,7 @@
                 :level-name 'strip
                 :continue-name "strip-warp"
                 :text-id (text-id strip-name) ;"Strip Mine"
-                :allow-when "drill-eggs-resolution"
+                :allow-when (lambda () (task-closed? "drill-eggs-resolution"))
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -247,7 +247,7 @@
                 :level-name 'mountain
                 :continue-name "mountain-warp-bottom"
                 :text-id (text-id mountain-bottom-name) ;"Mountain Temple (Bottom)"
-                :allow-when "mountain-lens-started"
+                :allow-when (lambda () (task-closed? "mountain-lens-started"))
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -276,7 +276,7 @@
                 :level-name 'drillmid
                 :continue-name "drill3-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "drill-mech-introduction"  ;; third drill platform mission required
+                :allow-when (lambda () (task-closed? "drill-mech-introduction"))  ;; third drill platform mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -297,7 +297,7 @@
                 :level-name 'vinroom
                 :continue-name "vinroom-warp"
                 :text-id (text-id vinroom-name) ;"Power Station"
-                :allow-when "fortress-save-friends-resolution" ;; third completed fortress mission required
+                :allow-when (lambda () (task-closed? "fortress-save-friends-resolution")) ;; third completed fortress mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -305,7 +305,7 @@
                 :level-name 'strip
                 :continue-name "strip-warp"
                 :text-id (text-id strip-name) ;"Strip Mine"
-                :allow-when "fortress-save-friends-resolution" ;; third completed fortress mission required
+                :allow-when (lambda () (task-closed? "fortress-save-friends-resolution")) ;; third completed fortress mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -313,7 +313,7 @@
                 :level-name 'drillmid
                 :continue-name "drill3-warp"
                 :text-id (text-id drill-name-1) ;"Drill Platform (Warp 1)"
-                :allow-when "fortress-save-friends-resolution" ;; third completed fortress mission required
+                :allow-when (lambda () (task-closed? "fortress-save-friends-resolution")) ;; third completed fortress mission required
                 :forbid-when #f
                 :on-activate #f
                 )
@@ -321,7 +321,7 @@
                 :level-name 'drillmid
                 :continue-name "drill-warp-gunship"
                 :text-id (text-id drill-name-2) ;"Drill Platform (Warp 2)"
-                :allow-when "fortress-save-friends-resolution" ;; third completed fortress mission required
+                :allow-when (lambda () (task-closed? "fortress-save-friends-resolution")) ;; third completed fortress mission required
                 :forbid-when #f
                 :on-activate #f
                 )

--- a/goal_src/jak2/engine/mods/warp-gate-menu/warp-gate-menu.gc
+++ b/goal_src/jak2/engine/mods/warp-gate-menu/warp-gate-menu.gc
@@ -11,12 +11,12 @@
           (available-count 0) ;; stores the amount of options that are available for selection 
           )
     (dotimes (i list-length)
-      (let* ((allow-task (-> menu i allow-when))
-              (forbid-task (-> menu i forbid-when))
-              )
-        ;; include the option if the `allow-when` task is closed,
-        ;; and the `forbid-when` task is either not set or not closed yet.
-        (when (and (or (not allow-task) (task-closed? allow-task)) (or (not forbid-task) (not (task-closed? forbid-task))))
+      (let* ((allowed? (-> menu i allow-when))
+             (forbidden? (-> menu i forbid-when)))
+        ;; include the option if `allowed?` is set and returns true,
+        ;; and `forbidden?` is either not set (not forbidden?) or does not return true (not (forbidden?)).
+        (when (and (or (not allowed?) (allowed?)) 
+                   (or (not forbidden?) (not (forbidden?))))
           (set! (-> available-idxs available-count) i) ;; store the available option indexes in `available-idxs` array  
           (+! available-count 1)
           )
@@ -179,10 +179,12 @@
           (list-length (-> menu length))
           )
     (dotimes (i list-length)
-      (let* ((allow-task (-> menu i allow-when))
-              (forbid-task (-> menu i forbid-when))
-              )
-        (when (and (or (not allow-task) (task-closed? allow-task)) (or (not forbid-task) (not (task-closed? forbid-task))))
+      (let* ((allowed? (-> menu i allow-when))
+             (forbidden? (-> menu i forbid-when)))
+        ;; include the option if `allowed?` is set and returns true,
+        ;; and `forbidden?` is either not set (not forbidden?) or does not return true (not (forbidden?)).
+        (when (and (or (not allowed?) (allowed?)) 
+                   (or (not forbidden?) (not (forbidden?))))
           (return #t)
           )
         )


### PR DESCRIPTION
Nick's warp gate menu system relies on the names of game task nodes to determine if each entry should be shown to the player or not. 

This update turns those properties - both `allow-when` and `forbid-when` - from strings into callback functions. The existing check conditions have been converted to functions that check the task node closure, for example:

```lisp
;; before 
:allow-when "drill-eggs-introduction"
;; after
:allow-when (lambda () (task-closed? "drill-eggs-introduction"))
```

This gives more flexibility to each entry to check for various conditions. For example, you can now check if the player has the Green Pass:

```lisp
:allow-when (lambda () (logtest? (-> *game-info* features) (game-feature pass-green)))
```

All the existing comments have been updated to reflect the change. Lightly tested in ArchipelaGOAL II. 